### PR TITLE
Logging in JSON format

### DIFF
--- a/olympus-app/olympus/settings.py
+++ b/olympus-app/olympus/settings.py
@@ -87,6 +87,30 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+# Logging in JSON format
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'json': {
+            '()': 'json_log_formatter.JSONFormatter',
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'json'
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+        },
+    }
+}
+
 # Third-party libraries
 
 # statsd_exporter daemon listens to UDP at localhost:8125.

--- a/olympus-app/requirements.txt
+++ b/olympus-app/requirements.txt
@@ -1,2 +1,3 @@
-Django==1.11.1
-statsd==3.2.1
+Django==3.1.3
+statsd==3.3.0
+JSON-log-formatter==0.3.0


### PR DESCRIPTION
Django development server emits logs in JSON format when running `curl http://localhost:8000/hello`.

```sh
$ ./manage.py runserver

{"request": "<socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 8000), raddr=('127.0.0.1', 55955)>", "server_time": "25/Nov/2020 20:33:40", "status_code": 200, "message": "\"GET /hello HTTP/1.1\" 200 13", "time": "2020-11-25T20:33:40.263240"}
```